### PR TITLE
Optionally disable mpi4py imports with an env flag

### DIFF
--- a/Lib/__init__.py
+++ b/Lib/__init__.py
@@ -2,11 +2,18 @@
 Distributed array
 """
 __all__ = ["mvMultiArrayIter"]
-from .mvMultiArrayIter import MultiArrayIter 
+from .mvMultiArrayIter import MultiArrayIter
+
+import os
+
+mpi_disabled = os.environ.get("CDMS_NO_MPI", "False").lower() == 'true'
 
 # is mpi4py available?
 hasMpi4py = True
 try:
+    # skip trying to load mpi4py module
+    if mpi_disabled:
+        raise Exception()
     from mpi4py import MPI
 except:
     hasMpi4py = False


### PR DESCRIPTION
This allows for the same environment to run on a compute node (where `mpi4py` should work) and a login node (where `mpi4py` often doesn't work) on HPC systems.